### PR TITLE
Adjust configuration check to allow use of io.js

### DIFF
--- a/lib/connect-wwwhisper.js
+++ b/lib/connect-wwwhisper.js
@@ -175,9 +175,9 @@ function configure() {
     throw new Error(
       'WWWHISPER_URL nor WWWHISPER_DISABLE environment variable set');
   }
-  if (!process.version.match('0.1(0|1).*')) {
-    throw new Error(
-      'wwwhipsper requires node version 0.10 or 0.11');
+  if (!process.execPath.match('iojs') && !process.version.match('0.1(0|1).*')) {
+	throw new Error(
+		'wwwhipsper requires node version 0.10 or 0.11 or io.js');
   }
   wwwhisperURL = url.parse(urlStr);
   if (wwwhisperURL.protocol === 'http:') {


### PR DESCRIPTION
I am only able to test this on a Windows machine at the moment so I've made an assumption that the execPath will contain "iojs" across platforms